### PR TITLE
Use nokogiri as HTML parser

### DIFF
--- a/lib/ogp/open_graph.rb
+++ b/lib/ogp/open_graph.rb
@@ -28,6 +28,7 @@ module OGP
       self.videos = []
 
       document = Nokogiri::HTML.parse(source)
+      document.encoding = 'utf-8'
       check_required_attributes(document)
       parse_attributes(document)
     end

--- a/ogp.gemspec
+++ b/ogp.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'nokogiri', '>= 1.8.5'
-  spec.add_dependency 'oga', '~> 2.10'
 
   spec.add_development_dependency 'bundler', '~> 1.13'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/ogp.gemspec
+++ b/ogp.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'nokogiri', '>= 1.8.5'
   spec.add_dependency 'oga', '~> 2.10'
 
   spec.add_development_dependency 'bundler', '~> 1.13'


### PR DESCRIPTION
Hello!

This gem is using Oga as HTML parser and it does not parse HTML with content's encoding. It makes some problem at non-ascii contents like Japanese.
I have replaced parser to Nokogiri. If you don't have a strong reason not to use Nokogiri, I would like you to merge this.