### PR TITLE
Don't error out when encountering unexpected/custom open graph tags.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ open_graph.title # => "Open Graph protocol"
 open_graph.type # => "website"
 open_graph.image.url # => "http://ogp.me/logo.png"
 open_graph.url # => "http://ogp.me/"
+
+# All open graph tags are additionally stored in a `data` hash so that custom
+# open graph tags can still be accessed.
+open_graph.data["title"] # => "Open Graph protocol"
 ```
 
 ## Contributing

--- a/lib/ogp/version.rb
+++ b/lib/ogp/version.rb
@@ -1,3 +1,3 @@
 module OGP
-  VERSION = '0.3.0'.freeze
+  VERSION = '0.4.0'.freeze
 end

--- a/ogp.gemspec
+++ b/ogp.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'oga', '~> 2.15'
 
-  spec.add_development_dependency 'bundler', '~> 1.13'
+  spec.add_development_dependency 'bundler', '>= 1.13'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.6'
   spec.add_development_dependency 'rubocop', '~> 0.49.1'

--- a/spec/fixtures/custom_attributes.html
+++ b/spec/fixtures/custom_attributes.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta property="og:title" content="Way Out" />
+  <meta property="og:description" content="Way Out, an album by Waterstrider on Spotify" />
+  <meta property="og:url" content="https://open.spotify.com/album/3NkIlQR6wZwPCQiP1vPjF8" />
+  <meta property="og:image" content="https://i.scdn.co/image/ab67616d0000b273eab5104fe2284f59731dd3f7" />
+  <meta property="og:type" content="music.album" />
+  <meta property="music:musician" content="https://open.spotify.com/artist/731UNhwHMAcSsurgHJxPHC" />
+  <meta property="music:release_date" content="2019-05-10" />
+  <meta property="music:song" content="https://open.spotify.com/track/6bewGDfgcmCjbAE2XHbwCh" />
+  <meta property="music:song:disc" content="1" />
+  <meta property="music:song:track" content="1" />
+  <meta property="og:restrictions:country:allowed" content="AR" />
+  <meta property="og:restrictions:country:allowed" content="AT" />
+  <meta property="og:restrictions:country:allowed" content="BG" />
+  <title></title>
+</head>
+<body>
+</body>
+</html>

--- a/spec/ogp/open_graph_spec.rb
+++ b/spec/ogp/open_graph_spec.rb
@@ -141,5 +141,17 @@ describe OGP::OpenGraph do
         expect(open_graph.image.url).to eql('https://www.example.com/image.jpg')
       end
     end
+
+    context 'with custom attributes' do
+      it 'should include them to the data hash' do
+        content = File.read("#{File.dirname(__FILE__)}/../fixtures/custom_attributes.html", encoding: 'ASCII-8BIT')
+        open_graph = OGP::OpenGraph.new(content)
+
+        expect(open_graph.title).to eql('Way Out')
+        expect(open_graph.data['title']).to eql(open_graph.title)
+        expect(open_graph.data['restrictions:country:allowed'].size).to eql(3)
+        expect(open_graph.data['restrictions:country:allowed'][0]).to eql('AR')
+      end
+    end
   end
 end


### PR DESCRIPTION
Add all open graph tags to `data` hash so that unexpected/custom open graph tags are accessible.