### PR TITLE
Move required attributes const under OGP namespace

### DIFF
--- a/lib/ogp/open_graph.rb
+++ b/lib/ogp/open_graph.rb
@@ -1,10 +1,11 @@
 require 'oga'
 require 'ostruct'
 
-REQUIRED_ATTRIBUTES = %w(title type image url).freeze
 
 module OGP
   class OpenGraph
+    REQUIRED_ATTRIBUTES = %w(title type image url).freeze
+
     # Accessor for storing all open graph data
     attr_accessor :data
 


### PR DESCRIPTION
This PR moves REQUIRED_ATTRIBUTE const under OGP::OpenGraph module namespace to avoid global namespace pollution, the const name seem generic