### PR TITLE
Add `required_attributes` option

### DIFF
--- a/lib/ogp/open_graph.rb
+++ b/lib/ogp/open_graph.rb
@@ -1,6 +1,7 @@
 require 'oga'
 require 'ostruct'
 
+DEFAULT_REQUIRED_ATTRIBUTES = %w(title type image url).freeze
 
 module OGP
   class OpenGraph
@@ -19,10 +20,12 @@ module OGP
     attr_accessor :locales
     attr_accessor :videos
 
-    def initialize(source)
+    def initialize(source, opts = {})
       if source.nil? || source.empty?
         raise ArgumentError, '`source` cannot be nil or empty.'
       end
+      
+      opts[:required_attributes] ||= DEFAULT_REQUIRED_ATTRIBUTES
 
       raise MalformedSourceError unless source.include?('</html>')
 
@@ -35,7 +38,7 @@ module OGP
       self.videos = []
 
       document = Oga.parse_html(source)
-      check_required_attributes(document)
+      check_required_attributes(document, opts[:required_attributes])
       parse_attributes(document)
     end
 
@@ -46,8 +49,8 @@ module OGP
 
   private
 
-    def check_required_attributes(document)
-      REQUIRED_ATTRIBUTES.each do |attribute_name|
+    def check_required_attributes(document, required_attributes)
+      required_attributes.each do |attribute_name|
         raise MissingAttributeError, "Missing required attribute: #{attribute_name}" unless attribute_exists(document, attribute_name)
       end
     end

--- a/spec/ogp/open_graph_spec.rb
+++ b/spec/ogp/open_graph_spec.rb
@@ -15,10 +15,18 @@ describe OGP::OpenGraph do
     end
 
     context 'with missing one of the required attributes' do
-      it 'should raise an error' do
+      it 'should raise an error by default' do
         content = File.read("#{File.dirname(__FILE__)}/../fixtures/missing_required_attributes.html")
 
         expect { OGP::OpenGraph.new(content) }.to raise_error(OGP::MissingAttributeError)
+      end
+      it 'should not raise an error if missing attribute is not required' do
+        content = File.read("#{File.dirname(__FILE__)}/../fixtures/missing_required_attributes.html")
+
+        open_graph = OGP::OpenGraph.new(content, { required_attributes: ['title', 'type', 'url'] })
+        expect(open_graph.title).to eql('The Rock')
+        expect(open_graph.type).to eql('video.movie')
+        expect(open_graph.url).to eql('http://www.imdb.com/title/tt0117500/')
       end
     end
 


### PR DESCRIPTION
This is an alternative to #5. I agree with the motivation expressed in #5: This gem should be helpful even if a website is not entirely spec-conformant. The default behavior is unchanged with this PR, but you can now pass an optional options hash as the second argument to the constructor. The options hash can include `required_attributes: ['title','etc']` where the array contents specify the opengraph attributes that must be present.